### PR TITLE
feat: Add Automatic NEP-330 Metadata Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ def get_count():
 def increment():
     count = near.storage_read('count', 0)
     count += 1
-    near.storage_read('count', count)
+    near.storage_write('count', count)
     return count
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nearc"
-version = "0.1.4"
+version = "0.2.0"
 description = "Python to WebAssembly compiler for NEAR smart contracts"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
# Add Automatic NEP-330 Metadata Support

This PR adds automatic support for the NEP-330 contract metadata standard to NEARC. The compiler now automatically injects a `contract_source_metadata` function into Python contracts during compilation if one doesn't already exist.

## Features

- ✅ Automatic compliance with NEP-330 for all compiled contracts
- ✅ Custom metadata configuration via `pyproject.toml`
- ✅ Zero changes required to existing contract code
- ✅ Preserves existing metadata functions if already defined by the developer

## Implementation Details

The implementation takes a simple approach by:

1. Checking if a contract already has a `contract_source_metadata` function
2. If not, reading metadata from `pyproject.toml` if available
3. Appending a properly decorated function to the end of the contract file
4. Using this modified file for compilation
5. Cleaning up the temporary file afterward

## Example Usage

Developers can define custom metadata in their `pyproject.toml`:

```toml
[tool.near.contract]
version = "0.2.0"
link = "https://github.com/myorg/mycontract"
standards = [
  { standard = "nep141", version = "1.0.0" },
  { standard = "nep148", version = "1.0.0" }
]
build_info = { build_id = "12345", timestamp = "2024-03-04T12:00:00Z" }
```

This generates a function that returns:

```json
{
  "version": "0.2.0",
  "link": "https://github.com/myorg/mycontract",
  "standards": [
    { "standard": "nep141", "version": "1.0.0" },
    { "standard": "nep148", "version": "1.0.0" },
    { "standard": "nep330", "version": "1.0.0" }
  ],
  "build_info": {
    "build_id": "12345",
    "timestamp": "2024-03-04T12:00:00Z"
  }
}
```

If no configuration is provided, a minimal implementation is added:

```json
{
  "standards": [
    { "standard": "nep330", "version": "1.0.0" }
  ]
}
```

## Testing Done

- Verified injection works when no metadata function exists
- Verified original function is preserved when it already exists
- Tested metadata extraction from `pyproject.toml`
- Verified compiled contracts include the metadata function
- Tested on Python 3.11

## Next Steps

Future improvements could include:
- Add build information automatically (compiler version, timestamp, etc.)
- Support for additional metadata fields
- More detailed documentation on metadata options