### PR TITLE
feat(metadata): Improved contract metadata handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,25 @@ The compiler automatically detects functions with `@near.export` and similar dec
 
 ## Contract Metadata (NEP-330)
 
-NEARC automatically adds NEP-330 compliant metadata to your contracts. You can customize the metadata by adding a `[tool.near.contract]` section to your `pyproject.toml` file:
+NEARC automatically adds NEP-330 compliant metadata to your contracts. You can customize the metadata in two ways:
+
+### Using Standard Project Metadata (PEP 621)
+
+You can use standard Python project metadata fields in your `pyproject.toml` file, which NEARC will automatically use to populate NEP-330 metadata:
+
+```toml
+[project]
+name = "my-near-contract"
+version = "0.2.0"
+description = "My NEAR smart contract"
+
+[project.urls]
+repository = "https://github.com/myorg/mycontract"
+```
+
+### Using NEAR-Specific Configuration
+
+For more advanced metadata and NEAR-specific fields, you can use the `[tool.near.contract]` section:
 
 ```toml
 [tool.near.contract]
@@ -93,7 +111,12 @@ standards = [
   { standard = "nep141", version = "1.0.0" },
   { standard = "nep148", version = "1.0.0" }
 ]
-build_info = { build_id = "12345" }
+build_info = {
+  build_environment = "docker.io/sourcescan/near-python@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471",
+  source_code_snapshot = "git+https://github.com/myorg/mycontract.git#main",
+  contract_path = ".",
+  build_command = ["nearc", "contract.py", "--no-debug"]
+}
 ```
 
 This will generate a `contract_source_metadata` function in your contract that returns:
@@ -107,11 +130,25 @@ This will generate a `contract_source_metadata` function in your contract that r
     { "standard": "nep148", "version": "1.0.0" },
     { "standard": "nep330", "version": "1.0.0" }
   ],
-  "build_info": { "build_id": "12345" }
+  "build_info": {
+    "build_environment": "docker.io/sourcescan/near-python@sha256:bf488476d9c4e49e36862bbdef2c595f88d34a295fd551cc65dc291553849471",
+    "source_code_snapshot": "git+https://github.com/myorg/mycontract.git#main",
+    "contract_path": ".",
+    "build_command": ["nearc", "contract.py", "--no-debug"]
+  }
 }
 ```
 
 If you already have a `contract_source_metadata` function in your contract, it will be preserved.
+
+### Metadata Field Priority
+
+When both standard project metadata and NEAR-specific configuration are present, NEARC uses the following priority order:
+
+1. Standard PEP 621 fields (`[project]` section)
+2. NEAR-specific fields (`[tool.near.contract]` section)
+
+The NEP-330 standard is always included in the standards list, ensuring compliance.
 
 ## How It Works
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nearc"
-version = "0.3.1"
+version = "0.3.2"
 description = "Python to WebAssembly compiler for NEAR smart contracts"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/nearc/metadata.py
+++ b/src/nearc/metadata.py
@@ -6,6 +6,7 @@ Contract metadata handling for the NEAR Python contract compiler.
 import json
 import tomllib
 from pathlib import Path
+from typing import Dict, Any
 
 from .utils import console
 
@@ -27,40 +28,14 @@ def inject_metadata_function(contract_path: Path) -> Path:
     if "def contract_source_metadata()" in content:
         return contract_path  # No injection needed
 
-    # Try to extract metadata from pyproject.toml if it exists
+    # Initialize metadata with NEP-330 standard
     metadata = {"standards": [{"standard": "nep330", "version": "1.0.0"}]}
 
+    # Extract metadata from pyproject.toml if it exists
     pyproject_path = contract_path.parent / "pyproject.toml"
     if pyproject_path.exists():
         try:
-            with open(pyproject_path, "rb") as f:
-                pyproject_data = tomllib.load(f)
-
-            # Extract metadata from pyproject.toml
-            contract_info = (
-                pyproject_data.get("tool", {}).get("near", {}).get("contract", {})
-            )
-
-            if "version" in contract_info:
-                metadata["version"] = contract_info["version"]
-            if "link" in contract_info:
-                metadata["link"] = contract_info["link"]
-            if "standards" in contract_info:
-                # Merge with existing standards, ensuring nep330 is included
-                standards = contract_info["standards"]
-                has_nep330 = False
-                for std in standards:
-                    if std.get("standard") == "nep330":
-                        has_nep330 = True
-                        break
-
-                if not has_nep330:
-                    standards.append({"standard": "nep330", "version": "1.0.0"})
-
-                metadata["standards"] = standards
-
-            if "build_info" in contract_info:
-                metadata["build_info"] = contract_info["build_info"]
+            metadata = extract_metadata_from_pyproject(pyproject_path, metadata)
         except Exception as e:
             console.print(
                 f"[yellow]Warning: Could not read metadata from pyproject.toml: {e}"
@@ -86,3 +61,58 @@ def contract_source_metadata():
     console.print("[cyan]Added NEP-330 metadata function to contract[/]")
 
     return modified_path
+
+
+def extract_metadata_from_pyproject(
+    pyproject_path: Path, base_metadata: Dict[str, Any]
+) -> Dict[str, Any]:
+    """
+    Extract metadata from pyproject.toml using standard fields when possible.
+
+    Args:
+        pyproject_path: Path to the pyproject.toml file
+        base_metadata: Initial metadata dictionary to extend
+
+    Returns:
+        Dict containing the updated metadata
+    """
+    with open(pyproject_path, "rb") as f:
+        pyproject_data = tomllib.load(f)
+
+    # Try to get metadata from project section (PEP 621 standard)
+    project_data = pyproject_data.get("project", {})
+
+    # Try to get NEAR-specific metadata from tool section
+    near_data = pyproject_data.get("tool", {}).get("near", {}).get("contract", {})
+
+    # Map standard pyproject.toml fields to NEP-330 metadata
+    if "version" in project_data:
+        base_metadata["version"] = project_data["version"]
+    elif "version" in near_data:
+        base_metadata["version"] = near_data["version"]
+
+    # Use standard URL field if available, fall back to NEAR-specific link
+    if "urls" in project_data and "repository" in project_data["urls"]:
+        base_metadata["link"] = project_data["urls"]["repository"]
+    elif "url" in project_data:
+        base_metadata["link"] = project_data["url"]
+    elif "link" in near_data:
+        base_metadata["link"] = near_data["link"]
+
+    # Handle standards field
+    if "standards" in near_data:
+        standards = list(
+            near_data["standards"]
+        )  # Create a new list to avoid modifying the original
+
+        # Ensure NEP-330 is included
+        if not any(std.get("standard") == "nep330" for std in standards):
+            standards.append({"standard": "nep330", "version": "1.0.0"})
+
+        base_metadata["standards"] = standards
+
+    # Handle build info
+    if "build_info" in near_data:
+        base_metadata["build_info"] = near_data["build_info"]
+
+    return base_metadata


### PR DESCRIPTION
This PR enhances the NEP-330 metadata handling by supporting standard Python project metadata fields (PEP 621) in addition to NEAR-specific configuration.

### Changes:

- Refactored the metadata extraction logic to look for standard fields in `[project]` section first
- Added support for `version` from `[project]` section
- Added support for repository URL from `[project.urls]` section

The code still maintains backward compatibility with existing `[tool.near.contract]` configuration.

Closes #4 