### PR TITLE
feat: Add commit hash to contract metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nearc"
-version = "0.3.6"
+version = "0.3.7"
 description = "Python to WebAssembly compiler for NEAR smart contracts"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/nearc/metadata.py
+++ b/src/nearc/metadata.py
@@ -41,6 +41,18 @@ def inject_metadata_function(contract_path: Path) -> Path:
                 f"[yellow]Warning: Could not read metadata from pyproject.toml: {e}"
             )
 
+    # Get Git information for the contract
+    from .reproducible import get_git_info
+
+    git_info = get_git_info(contract_path.parent)
+
+    # Add Git information directly to metadata
+    if git_info:
+        if "repository" in git_info:
+            metadata["link"] = git_info["repository"]
+        if "commit" in git_info:
+            metadata["source_version"] = git_info["commit"]
+
     # Create the function code
     metadata_code = f"""
 


### PR DESCRIPTION
As @frol points out:
> The metadata should also include the git repo with commit hash, otherwise SourceScan doesn't know which version of the code needs to be compiled