### PR TITLE
feat: Auto-detect Contract Files and Improve Module Discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ NEARC is a specialized compiler that transforms Python smart contracts into WebA
 - Optimized WebAssembly output
 - Automatic NEP-330 contract metadata compliance
 - **Reproducible builds for contract verification**
+- **Auto-detection of contract entrypoint files**
 
 ## Prerequisites
 
@@ -41,8 +42,11 @@ pip install nearc
 ## Usage
 
 ```bash
-# Basic usage
+# Basic usage with explicit contract file
 nearc contract.py
+
+# Auto-detect contract file (looks for __init__.py or main.py)
+nearc
 
 # Specify output file
 nearc contract.py -o my-contract.wasm
@@ -54,7 +58,7 @@ nearc contract.py --venv my-venv
 nearc contract.py --rebuild
 
 # Initialize reproducible build configuration
-nearc contract.py --init-reproducible-config
+nearc --init-reproducible-config
 
 # Build reproducibly for contract verification
 nearc contract.py --reproducible
@@ -64,11 +68,35 @@ nearc contract.py --reproducible
 
 | Option                      | Description                                                |
 |-----------------------------|------------------------------------------------------------|
+| `contract`                  | Path to contract file (optional - auto-detects if omitted) |
 | `--output`, `-o`           | Output WASM filename (default: derived from contract name) |
 | `--venv`                   | Path to virtual environment (default: `.venv`)             |
 | `--rebuild`                | Force rebuild of all components                            |
 | `--init-reproducible-config`| Initialize configuration for reproducible builds           |
 | `--reproducible`           | Build reproducibly in Docker for contract verification     |
+
+### Contract Entrypoint
+
+NEARC requires a single entrypoint file that contains all the exported functions (functions with `@near.export` or other export decorators). While your contract can span multiple files, all decorated functions must be in this entrypoint file.
+
+If you don't specify a contract file, NEARC will auto-detect the entrypoint by looking for:
+
+1. `__init__.py` in the current directory (first priority)
+2. `main.py` in the current directory (second priority)
+
+Best practices:
+- For simple contracts: Use a single file with all your code
+- For complex contracts: Use `__init__.py` as your entrypoint that imports and re-exports functions from other modules
+
+Example project structure:
+```
+my-contract/
+├── __init__.py      # Entrypoint with all @export decorators
+├── logic.py         # Supporting code (no export decorators)
+├── models.py        # Data models and utilities
+└── utils/
+    └── helpers.py   # Additional utilities
+```
 
 ## Writing NEAR Contracts in Python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,12 @@
 [project]
 name = "nearc"
-version = "0.3.8"
+version = "0.3.9"
 description = "Python to WebAssembly compiler for NEAR smart contracts"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "near-abi-py>=0.1.1",
+    "pathspec>=0.12.1",
     "rich>=13.9.4",
     "rich-click>=1.8.6",
     "tomli-w>=1.2.0",

--- a/src/nearc/cli.py
+++ b/src/nearc/cli.py
@@ -96,7 +96,6 @@ def main(
             )
             sys.exit(1)
 
-    contract_dir = contract_path.parent
     venv_path = Path(venv).resolve()
 
     # Determine output path if not specified

--- a/src/nearc/manifest.py
+++ b/src/nearc/manifest.py
@@ -106,7 +106,7 @@ class ManifestGenerator:
             spec = pathspec.PathSpec.from_lines(
                 pathspec.patterns.GitWildMatchPattern, gitignore_patterns
             )
-            console.print(f"[cyan]Using .gitignore patterns for module filtering[/]")
+            console.print("[cyan]Using .gitignore patterns for module filtering[/]")
             return spec
 
     def find_local_modules(self) -> List[Path]:

--- a/src/nearc/manifest.py
+++ b/src/nearc/manifest.py
@@ -5,149 +5,289 @@ Build manifest generation for the NEAR Python contract compiler.
 
 import os
 from pathlib import Path
-from typing import Set, List
+from typing import Set, List, Tuple, Optional, Any
 
-from .analyzer import is_micropython_module, get_excluded_stdlib_packages
+from .analyzer import is_micropython_module, MPY_STDLIB_PACKAGES
 from .utils import console, find_site_packages
 
 
-def generate_manifest(
-    contract_path: Path, imports: Set[str], venv_path: Path, build_dir: Path
-) -> tuple[Path, List[str]]:
-    """
-    Generate a MicroPython manifest file that includes all necessary modules.
+class ManifestGenerator:
+    """Handles the generation of build manifests for NEAR Python contracts."""
 
-    Args:
-        contract_path: Path to the contract file
-        imports: Set of imported module names
-        venv_path: Path to the virtual environment
-        build_dir: Path to the build directory
+    def __init__(
+        self,
+        contract_path: Path,
+        imports: Set[str],
+        exports: Set[str],
+        venv_path: Path,
+        build_dir: Path,
+    ):
+        self.contract_path = contract_path
+        self.imports = imports
+        self.exports = exports
+        self.venv_path = venv_path
+        self.build_dir = build_dir
+        self.contract_dir = contract_path.parent
+        self.site_packages = self._get_site_packages()
+        self.excluded_stdlib_packages = self._get_excluded_stdlib_packages()
+        self.gitignore_spec = self._load_gitignore_spec()
 
-    Returns:
-        Tuple of (manifest_path, missing_modules)
-    """
-    manifest_path = build_dir / "manifest.py"
-    site_packages = find_site_packages(venv_path)
-
-    if not site_packages:
-        console.print(f"[red]Error: Could not find site-packages in {venv_path}")
-        import sys
-
-        sys.exit(1)
-
-    # Get excluded packages
-    excluded_stdlib_packages = get_excluded_stdlib_packages(contract_path.parent)
-    if excluded_stdlib_packages:
-        console.print(
-            f"Excluding MicroPython stdlib packages: {', '.join(excluded_stdlib_packages)}"
-        )
-
-    with open(manifest_path, "w") as f:
-        f.write("# THIS FILE IS GENERATED, DO NOT EDIT\n\n")
-
-        # Add stdlib packages
-        from .analyzer import MPY_STDLIB_PACKAGES
-
-        included_stdlib_packages = set(MPY_STDLIB_PACKAGES) - set(
-            excluded_stdlib_packages
-        )
-
-        f.write(
-            "\n".join(
-                f'require("{module}")'
-                for module in sorted(included_stdlib_packages)  # Deterministic builds
+    def _get_site_packages(self) -> Path:
+        """Get the site-packages directory from the virtual environment."""
+        site_packages = find_site_packages(self.venv_path)
+        if not site_packages:
+            console.print(
+                f"[red]Error: Could not find site-packages in {self.venv_path}"
             )
-        )
+            import sys
 
-        # Add typing modules
-        f.write("\n\n# Typing modules\n")
-        f.write(
-            "\n".join(
-                f'module("{mod}.py", base_path="$(PORT_DIR)/extra/typing")'
-                for mod in ["typing", "typing_extensions"]
+            sys.exit(1)
+        return site_packages
+
+    def _get_excluded_stdlib_packages(self) -> List[str]:
+        """Get excluded stdlib packages from pyproject.toml."""
+        pyproject_path = self.contract_dir / "pyproject.toml"
+        excluded_packages = []
+
+        if pyproject_path.is_file():
+            try:
+                import tomllib
+
+                with open(pyproject_path, "rb") as file:
+                    pyproject_data = tomllib.load(file)
+                excluded_packages = (
+                    pyproject_data.get("tool", {})
+                    .get("near-py-tool", {})
+                    .get("exclude-micropython-stdlib-packages", [])
+                )
+            except Exception as e:
+                console.print(
+                    f"[yellow]Warning: Could not read exclusions from pyproject.toml: {e}"
+                )
+
+        if excluded_packages:
+            console.print(
+                f"Excluding MicroPython stdlib packages: {', '.join(excluded_packages)}"
             )
-        )
 
-        # Find external dependencies (non-MicroPython modules)
+        return excluded_packages
+
+    def _load_gitignore_spec(self) -> Optional[Any]:
+        """Load gitignore patterns if available."""
+        try:
+            import pathspec
+        except ImportError:
+            console.print(
+                "[yellow]pathspec library not found, gitignore filtering disabled[/]"
+            )
+            console.print("[yellow]Install with: pip install pathspec[/]")
+            return None
+
+        gitignore_path = self.contract_dir / ".gitignore"
+        if not gitignore_path.exists():
+            return None
+
+        with open(gitignore_path, "r") as gitignore_file:
+            gitignore_patterns = gitignore_file.read().splitlines()
+
+            # Add common Python patterns if not already specified
+            default_patterns = [
+                "__pycache__/",
+                "*.py[cod]",
+                "*$py.class",
+                "*.so",
+                "build/",
+                "dist/",
+            ]
+            for pattern in default_patterns:
+                if pattern not in gitignore_patterns:
+                    gitignore_patterns.append(pattern)
+
+            spec = pathspec.PathSpec.from_lines(
+                pathspec.patterns.GitWildMatchPattern, gitignore_patterns
+            )
+            console.print(f"[cyan]Using .gitignore patterns for module filtering[/]")
+            return spec
+
+    def find_local_modules(self) -> List[Path]:
+        """Find all local Python modules in the contract directory, respecting .gitignore."""
+        local_modules = []
+        always_exclude = [".git", ".venv", "venv", "__pycache__", "build"]
+
+        console.print("[cyan]Scanning for local Python modules...[/]")
+
+        for py_file in self.contract_dir.glob("**/*.py"):
+            # Skip the main contract file and generated files
+            if py_file.name == self.contract_path.name or py_file.name.endswith(
+                ("_with_metadata.py", "_with_abi.py")
+            ):
+                continue
+
+            # Get relative path for gitignore matching
+            rel_path = py_file.relative_to(self.contract_dir)
+            rel_path_str = str(rel_path).replace("\\", "/")
+
+            # Skip based on always_exclude patterns
+            if any(exclude in str(py_file) for exclude in always_exclude):
+                continue
+
+            # Skip if matches gitignore patterns
+            if (
+                self.gitignore_spec
+                and hasattr(self.gitignore_spec, "match_file")
+                and self.gitignore_spec.match_file(rel_path_str)
+            ):
+                console.print(
+                    f"  [dim yellow]Ignoring (gitignore match): {rel_path}[/]"
+                )
+                continue
+
+            local_modules.append(rel_path)
+            console.print(f"  [dim]Found local module: {rel_path}[/]")
+
+        if not local_modules:
+            console.print(
+                "[yellow]No local modules found besides the main contract file[/]"
+            )
+        else:
+            console.print(
+                f"[green]Found {len(local_modules)} local modules to include[/]"
+            )
+
+        return local_modules
+
+    def process_external_dependencies(
+        self, local_modules: List[Path]
+    ) -> List[Tuple[str, str]]:
+        """Process external dependencies from imports list."""
         external_modules = {
-            name.split(".")[0] for name in imports if not is_micropython_module(name)
+            name.split(".")[0]
+            for name in self.imports
+            if not is_micropython_module(name)
         }
 
-        # Process external dependencies
         external_deps = []
-        local_deps = []
-        rel_path = os.path.relpath(site_packages, manifest_path.parent).replace(
-            "\\", "/"
-        )
-        contract_dir = contract_path.parent
-        contract_rel_path = os.path.relpath(contract_dir, manifest_path.parent).replace(
-            "\\", "/"
-        )
-
         missing_modules = []
-        for base_module in external_modules:
-            module_dir = site_packages / base_module
-            module_file = site_packages / f"{base_module}.py"
-            local_module_file = contract_dir / f"{base_module}.py"
 
-            # Check if it's a local module first
-            if local_module_file.exists():
-                local_deps.append(
-                    f'module("{base_module}.py", base_path="{contract_rel_path}")'
-                )
-            # Then check in site-packages
-            elif module_dir.is_dir():
-                external_deps.append(
-                    f'package("{base_module}", base_path="{rel_path}")'
-                )
+        for base_module in sorted(external_modules):
+            # Check if it's a local module
+            local_module_file = self.contract_dir / f"{base_module}.py"
+            local_module_dir = self.contract_dir / base_module
+            local_module_init = local_module_dir / "__init__.py"
+
+            if local_module_file.exists() or (
+                local_module_dir.is_dir() and local_module_init.exists()
+            ):
+                continue  # Local module, already handled
+
+            # Check in site-packages
+            module_dir = self.site_packages / base_module
+            module_file = self.site_packages / f"{base_module}.py"
+
+            if module_dir.is_dir():
+                external_deps.append((base_module, "package"))
             elif module_file.exists():
-                external_deps.append(
-                    f'module("{base_module}.py", base_path="{rel_path}")'
-                )
+                external_deps.append((base_module, "module"))
             else:
                 missing_modules.append(base_module)
+                console.print(
+                    f"[yellow]Warning: Could not find module {base_module} in {self.site_packages}"
+                )
 
-        if external_deps:
-            f.write("\n\n# External dependencies\n")
-            f.write("\n".join(external_deps))
+        return external_deps
 
-        if local_deps:
-            f.write("\n\n# Local modules\n")
-            f.write("\n".join(local_deps))
+    def write_manifest(
+        self, local_modules: List[Path], external_deps: List[Tuple[str, str]]
+    ) -> Path:
+        """Write the manifest file."""
+        manifest_path = self.build_dir / "manifest.py"
 
-        # Include the contract file
-        f.write("\n\n# Contract\n")
-        f.write(f'module("{contract_path.name}", base_path="..")')
+        with open(manifest_path, "w") as f:
+            f.write("# THIS FILE IS GENERATED, DO NOT EDIT\n\n")
 
-    return manifest_path, missing_modules
+            # Add stdlib packages
+            included_stdlib_packages = set(MPY_STDLIB_PACKAGES) - set(
+                self.excluded_stdlib_packages
+            )
+            f.write(
+                "\n".join(
+                    f'require("{module}")'
+                    for module in sorted(included_stdlib_packages)
+                )
+            )
 
+            # Add typing modules
+            f.write("\n\n# Typing modules\n")
+            f.write(
+                "\n".join(
+                    f'module("{mod}.py", base_path="$(PORT_DIR)/extra/typing")'
+                    for mod in ["typing", "typing_extensions"]
+                )
+            )
 
-def generate_export_wrappers(
-    exports: Set[str], contract_name: str, build_dir: Path
-) -> Path:
-    """
-    Generate C wrappers for exported functions.
+            # Add local modules
+            if local_modules:
+                f.write("\n\n# Local modules\n")
+                contract_rel_path = os.path.relpath(
+                    self.contract_dir, manifest_path.parent
+                ).replace("\\", "/")
 
-    Args:
-        exports: Set of exported function names
-        contract_name: Name of the contract file
-        build_dir: Path to the build directory
+                for rel_path in sorted(local_modules):
+                    f.write(f'module("{rel_path}", base_path="{contract_rel_path}")\n')
 
-    Returns:
-        Path to the generated wrappers file
-    """
-    wrappers_path = build_dir / "export_wrappers.c"
+            # Add external dependencies
+            if external_deps:
+                f.write("\n\n# External dependencies\n")
+                rel_path_str = os.path.relpath(
+                    self.site_packages, manifest_path.parent
+                ).replace("\\", "/")
 
-    with open(wrappers_path, "w") as f:
-        f.write("/* Generated export wrappers for NEAR contract */\n\n")
-        f.write("void run_frozen_fn(const char *file_name, const char *fn_name);\n\n")
+                for module_name, module_type in external_deps:
+                    if module_type == "package":
+                        f.write(
+                            f'package("{module_name}", base_path="{rel_path_str}")\n'
+                        )
+                    else:
+                        f.write(
+                            f'module("{module_name}.py", base_path="{rel_path_str}")\n'
+                        )
 
-        for export in sorted(exports):
-            f.write(f"void {export}() {{\n")
-            f.write(f'    run_frozen_fn("{contract_name}", "{export}");\n')
-            f.write("}\n\n")
+            # Add contract file
+            f.write("\n\n# Contract\n")
+            f.write(f'module("{self.contract_path.name}", base_path="..")')
 
-    return wrappers_path
+        return manifest_path
+
+    def write_wrappers(self) -> Path:
+        """Generate export wrappers file."""
+        wrappers_path = self.build_dir / "export_wrappers.c"
+
+        with open(wrappers_path, "w") as f:
+            f.write("/* Generated export wrappers for NEAR contract */\n\n")
+            f.write(
+                "void run_frozen_fn(const char *file_name, const char *fn_name);\n\n"
+            )
+
+            for export in sorted(self.exports):
+                f.write(f"void {export}() {{\n")
+                f.write(
+                    f'    run_frozen_fn("{self.contract_path.name}", "{export}");\n'
+                )
+                f.write("}\n\n")
+
+        return wrappers_path
+
+    def generate(self) -> Tuple[Path, Path]:
+        """Generate all build files."""
+        local_modules = self.find_local_modules()
+        external_deps = self.process_external_dependencies(local_modules)
+
+        console.print("[cyan]Generating build files...[/]", end="")
+        manifest_path = self.write_manifest(local_modules, external_deps)
+        wrappers_path = self.write_wrappers()
+        console.print(" done")
+
+        return manifest_path, wrappers_path
 
 
 def prepare_build_files(
@@ -156,9 +296,9 @@ def prepare_build_files(
     exports: Set[str],
     venv_path: Path,
     build_dir: Path,
-) -> tuple[Path, Path]:
+) -> Tuple[Path, Path]:
     """
-    Generate the manifest and wrappers files.
+    Generate manifest and wrapper files for NEAR contract compilation.
 
     Args:
         contract_path: Path to the contract file
@@ -170,30 +310,5 @@ def prepare_build_files(
     Returns:
         Tuple of (manifest_path, wrappers_path)
     """
-    # Find site-packages directory
-    site_packages = find_site_packages(venv_path)
-    if not site_packages:
-        console.print(f"[red]Error: Could not find site-packages in {venv_path}")
-        import sys
-
-        sys.exit(1)
-
-    # Generate manifest and get missing modules
-    manifest_result, missing_modules = generate_manifest(
-        contract_path, imports, venv_path, build_dir
-    )
-
-    # Print warnings for missing modules before the "Generating build files" message
-    for module in missing_modules:
-        console.print(
-            f"[yellow]Warning: Could not find module {module} in {site_packages}"
-        )
-
-    console.print("[cyan]Generating build files...[/]", end="")
-
-    # Generate wrappers
-    wrappers_path = generate_export_wrappers(exports, contract_path.name, build_dir)
-
-    console.print(" done")
-
-    return manifest_result, wrappers_path
+    generator = ManifestGenerator(contract_path, imports, exports, venv_path, build_dir)
+    return generator.generate()

--- a/uv.lock
+++ b/uv.lock
@@ -136,10 +136,11 @@ wheels = [
 
 [[package]]
 name = "nearc"
-version = "0.3.7"
+version = "0.3.9"
 source = { editable = "." }
 dependencies = [
     { name = "near-abi-py" },
+    { name = "pathspec" },
     { name = "rich" },
     { name = "rich-click" },
     { name = "tomli-w" },
@@ -157,6 +158,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "near-abi-py", specifier = ">=0.1.1" },
+    { name = "pathspec", specifier = ">=0.12.1" },
     { name = "rich", specifier = ">=13.9.4" },
     { name = "rich-click", specifier = ">=1.8.6" },
     { name = "tomli-w", specifier = ">=1.2.0" },
@@ -169,6 +171,15 @@ dev = [
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "ruff", specifier = ">=0.9.9" },
     { name = "types-toml", specifier = ">=0.10.8.20240310" },
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Overview
This PR adds two major improvements to the NEARC compiler:

1. **Auto-detection of contract entrypoint files** - When no contract file is explicitly specified, NEARC will automatically look for `__init__.py` or `main.py` in the current directory.
2. **Comprehensive module discovery** - NEARC now properly scans the project directory to find all local modules, respecting `.gitignore` patterns.

## Key Changes

### Contract Auto-detection
- Modified `cli.py` to make the contract argument optional
- Added logic to auto-detect `__init__.py` or `main.py` in the current directory
- Improved error messages when no contract file can be found

### Improved Module Discovery
- Completely refactored `manifest.py` with a focus on simplicity
- Added support for scanning all local Python modules in a project
- Added support for respecting `.gitignore` patterns
- Fixed false warnings about missing modules that are actually local
- Eliminated the need for complex recursive import analysis

### Documentation
- Updated README to document the auto-detection feature
- Added guidance on structuring multi-file projects
- Clarified that all exported functions must be in the entrypoint file

## Testing
- Tested with single-file contracts
- Tested with multi-file projects with various structures
- Verified auto-detection works correctly
- Confirmed that all local modules are properly included
- Checked that `.gitignore` patterns are respected

## Dependencies
- Added optional dependency on `pathspec` for `.gitignore` pattern matching

This PR simplifies contract development by eliminating the need to explicitly specify the entrypoint file in most cases, and by ensuring all local modules are properly included regardless of import patterns.

## Demo
![result](https://github.com/user-attachments/assets/cf8baa05-f56d-4bee-b70e-e7c1ca8f81bb)

Closes #13 